### PR TITLE
[semver:minor] Cache rubocop info for faster linting runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed example.
 ### Removed
  - Removed parallelism from test-rails and test-gem since breaking code coverage.
+
+## [2.1.0] - 2022-02-18
+### Changed
+ - Added caching to Rubocop runs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This includes:
 
 * Code climate reporter test id added as a CircleCI project environment variable as `CC_TEST_REPORTER_ID`.
 * Docker username and password added to a CircleCI context as `DOCKER_USER` and `DOCKER_PASS`.
-  
+
 ## Development
 
 ### Requirements
@@ -30,7 +30,7 @@ $ circleci orb validate orb.yml
 
 ### How to Publish
 * Create and push a branch with your new features.
-* When ready to publish a new production version, create a Pull Request from _feature branch_ to `master`.
+* When ready to publish a new production version, create a Pull Request from _feature branch_ to `main`.
 * The title of the pull request must contain a special semver tag: `[semver:<segment>]` where `<segment>` is replaced by one of the following values.
 
 | Increment | Description|

--- a/src/commands/rubocop-with-caching.yml
+++ b/src/commands/rubocop-with-caching.yml
@@ -1,0 +1,23 @@
+description: Runs rubocop with cache restore and save
+
+parameters:
+  path:
+    description: The path of the rubocop cache
+    type: string
+    default: "../.cache/rubocop_cache"
+  cache-version:
+    description: A prefix to the cache key for versioning
+    type: string
+    default: "v1"
+
+steps:
+  - restore_cache:
+      keys:
+        - << parameters.cache-version >>-rubocop-cache-{{ checksum ".rubocop.yml" }}-{{ .Branch }}
+        - << parameters.cache-version >>-rubocop-cache-{{ checksum ".rubocop.yml" }}-main
+        - << parameters.cache-version >>-rubocop-cache-{{ checksum ".rubocop.yml" }}
+  - ruby/rubocop-check
+  - save_cache:
+      key: << parameters.cache-version >>-rubocop-cache-{{ checksum ".rubocop.yml" }}-{{ .Branch }}-{{ epoch }}
+      paths:
+        - << parameters.path >>

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -12,4 +12,4 @@ parameters:
 steps:
   - checkout
   - gem-install-deps
-  - ruby/rubocop-check
+  - rubocop-with-caching


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

* Add new command for storing the rubocop cache between runs

## Motivation:

To speed up linting when Rubocop is able to use its cache

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.
