### PR TITLE
[semver:minor] Allow bundle caching when linting

### DIFF
--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -11,5 +11,5 @@ parameters:
 
 steps:
   - checkout
-  - gem-install-deps
+  - ruby/install-deps
   - rubocop-with-caching


### PR DESCRIPTION
By using the command from the ruby orb, this is done automagically and it should speed up the slowest part of linting at the moment (~20 of ~26 seconds).