### PR TITLE
[semver:minor] Update the redis image to the non-deprecated images

### DIFF
--- a/src/executors/ruby-postgres-redis.yml
+++ b/src/executors/ruby-postgres-redis.yml
@@ -23,4 +23,4 @@ docker:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: sekret
-  - image: circleci/redis:3
+  - image: cimg/redis:6.2


### PR DESCRIPTION
Redis images are available here now: https://hub.docker.com/r/cimg/redis/tags