### PR TITLE
Bump ruby orb

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,5 +10,5 @@ display:
 orbs:
   docker: circleci/docker@2.0.2
   node: circleci/node@5.0.0
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1.4.1
   browser-tools: circleci/browser-tools@1.2.4


### PR DESCRIPTION
To get the fix for https://github.com/CircleCI-Public/ruby-orb/issues/86 which is preventing all tests from running.