### PR TITLE
[semver:major] Default Ruby to 3.2.2 and bump orb dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.2.0] - 2023-01-30
 ### Added
   - Adds extra_build_args param to docker/build.
+
+## [4.0.0] - 2023-05-12
+### Changed
+ - Default Ruby changed to 3.2.2.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,7 +8,7 @@ display:
   source_url: "https://github.com/sul-dlss/ruby-rails-orb"
 
 orbs:
-  docker: circleci/docker@2.0.2
-  node: circleci/node@5.0.0
-  ruby: circleci/ruby@1.4.1
-  browser-tools: circleci/browser-tools@1.2.4
+  docker: circleci/docker@2.2.0
+  node: circleci/node@5.1.0
+  ruby: circleci/ruby@2.0.1
+  browser-tools: circleci/browser-tools@1.4.1

--- a/src/executors/ruby-postgres-redis.yml
+++ b/src/executors/ruby-postgres-redis.yml
@@ -3,7 +3,7 @@ description: >
 
 parameters:
   ruby-tag:
-    default: '3.0.3'
+    default: '3.2.2'
     description: The `cimg/ruby` Docker image version tag.
     type: string
   postgres-tag:

--- a/src/executors/ruby-postgres.yml
+++ b/src/executors/ruby-postgres.yml
@@ -3,7 +3,7 @@ description: >
 
 parameters:
   ruby-tag:
-    default: '3.0.3'
+    default: '3.2.2'
     description: The `cimg/ruby` Docker image version tag.
     type: string
   postgres-tag:

--- a/src/executors/ruby.yml
+++ b/src/executors/ruby.yml
@@ -3,7 +3,7 @@ description: >
 
 parameters:
   ruby-tag:
-    default: '3.0.3'
+    default: '3.2.2'
     description: The `cimg/ruby` Docker image version tag.
     type: string
 


### PR DESCRIPTION
**SEMVER Update Type:**
- [X] Major
- [ ] Minor
- [ ] Patch

Keep pace with changes upstream: bump Ruby to 3.2.2 and bump the orbs too.
