### PR TITLE
[semver:patch] Update lint-erb.yml

### DIFF
--- a/src/jobs/lint-erb.yml
+++ b/src/jobs/lint-erb.yml
@@ -14,4 +14,4 @@ steps:
   - ruby/install-deps
   - run:
       name: Lint ERBs
-      command: 'bundle exec erblint --lint-all --format compact'
+      command: 'bundle exec erb_lint --lint-all --format compact'


### PR DESCRIPTION
There is a deprecation warning about `erblint` being deprecated in favor of `erb_lint`. I veriifed this works locally.