### PR TITLE
[semver:minor] Bump all dependencies

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,8 +8,8 @@ display:
   source_url: "https://github.com/sul-dlss/ruby-rails-orb"
 
 orbs:
+  browser-tools: circleci/browser-tools@1.5.2
   codecov: codecov/codecov@5.2.0
-  docker: circleci/docker@2.8.1
-  node: circleci/node@7.0.0
-  ruby: circleci/ruby@2.3.1
-  browser-tools: circleci/browser-tools@1.5.0
+  docker: circleci/docker@2.8.2
+  node: circleci/node@7.1.0
+  ruby: circleci/ruby@2.4.0


### PR DESCRIPTION
Primarily to pick up a patch-level release to the browser-tools orb which fixes the installation of the latest Firefox (135.0), but also just to keep pace.

