### PR TITLE
[semver:minor] Remove support for CodeClimate test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add support for CodeCov (eventual replacement for CodeClimate, we hope)
+
+## [4.5.0] - 2025-03-11
+
+### Changed
+
+- Remove support for CodeClimate

--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ ruby-rails orb is a CircleCI orb that is optimized for DLSS Infrastructure Ruby 
 
 This includes:
 * Using Postgres for a database.
-* Using Code Climate (or CodeCov) for code coverage.
-* Validating openapi specifications.
+* Using CodeCov for code coverage.
+* Validating OpenAPI specifications.
 * Building Docker images.
 
 ## Requirements
 
-* CodeClimate reporter test id added as a CircleCI project environment variable as `CC_TEST_REPORTER_ID`, if using CodeClimate.
 * CodeCov token added as a CircleCI project environment variable as `CODECOV_TOKEN`, if using CodeCov.
 * Docker username and password added to a CircleCI context as `DOCKER_USER` and `DOCKER_PASS`.
 

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -2,45 +2,22 @@ description: >
   Runs rspec wrapped with code coverage.
 
 parameters:
-  cc-test-reporter-id:
-    default: CC_TEST_REPORTER_ID
-    description: |
-      Name of environment variable storing your Code Climate reporter test id
-    type: env_var_name
   codecov-token:
     default: CODECOV_TOKEN
     description: |
       Name of environment variable storing your CodeCov token
     type: env_var_name
   use-codecov:
-    default: false
-    description: True if project uses CodeCov instead of CodeClimate.
+    default: true
+    description: True because CodeClimate is no longer supported
     type: boolean
 
 steps:
-  - unless:
-      condition: << parameters.use-codecov >>
-      steps:
-        - run:
-            name: Setup Code Climate test-reporter
-            command: |
-              curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-              chmod +x ./cc-test-reporter
-              ./cc-test-reporter before-build
-        - run:
-            command: gem install rspec_junit_formatter
-            name: Install Rspec Junit Formatter gem
   - ruby/rspec-test:
       rerun-fail: true
   - when:
       condition: << parameters.use-codecov >>
       steps:
         - codecov/upload
-  - unless:
-      condition: << parameters.use-codecov >>
-      steps:
-        - run:
-            name: upload test coverage report to Code Climate
-            command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $? -r $<< parameters.cc-test-reporter-id >>
   - store_artifacts:
       path: tmp/capybara

--- a/src/jobs/test-gem.yml
+++ b/src/jobs/test-gem.yml
@@ -9,8 +9,8 @@ parameters:
     description: Executor to use for this job, defaults to ruby executor
     type: executor
   use-codecov:
-    default: false
-    description: True if project uses CodeCov instead of CodeClimate.
+    default: true
+    description: True because CodeClimate is no longer supported
     type: boolean
   before-test:
     default: []

--- a/src/jobs/test-rails.yml
+++ b/src/jobs/test-rails.yml
@@ -25,8 +25,8 @@ parameters:
     description: True to install Java
     type: boolean
   use-codecov:
-    default: false
-    description: True if project uses CodeCov instead of CodeClimate.
+    default: true
+    description: True because CodeClimate is no longer supported
     type: boolean
   db-prepare-command:
     default: db:test:prepare


### PR DESCRIPTION
Fixes #24

This commit yanks CodeClimate support which none of our projects use anymore, and changes the default value of the `use-codecov` param to true.
