### PR TITLE
Call herb via bin script

### DIFF
--- a/src/jobs/herblint.yml
+++ b/src/jobs/herblint.yml
@@ -14,4 +14,4 @@ steps:
   - ruby/install-deps
   - run:
       name: Lint herbs
-      command: bin/rake herb
+      command: bin/herb


### PR DESCRIPTION
Run herb linting directly via bin script instead of loading the rails env through bin/rake